### PR TITLE
Make separator line for project cards 1px thick.

### DIFF
--- a/api/axios.ts
+++ b/api/axios.ts
@@ -8,7 +8,9 @@ import Axios from "axios";
 // );
 
 export const axios = Axios.create({
-  baseURL: process.env.NEXT_PUBLIC_API_BASE_URL,
+  baseURL:
+    process.env.NEXT_PUBLIC_API_BASE_URL ||
+    "https://hidden-bastion-18291-71157d9a31ff.herokuapp.com",
 });
 
 axios.interceptors.response.use(

--- a/features/projects/components/project-card/project-card.module.scss
+++ b/features/projects/components/project-card/project-card.module.scss
@@ -19,7 +19,7 @@
 
 .bottomContainer {
   padding: space.$s4 space.$s6;
-  border-top: 3px solid color.$gray-200;
+  border-top: 1px solid color.$gray-200;
   display: flex;
   justify-content: flex-end;
 }


### PR DESCRIPTION
Bug fix!

Ignore all the other files other than `features/projects/components/project-card/project-card.module.scss`

Everything else is kinda set up-y stuff for the mock api. _Technically_ not super good, but, y'know. Lets give a dog a bone and move on.